### PR TITLE
Fix #33: The tiniest patch you can get to acquire perl 5.26 compatibility.

### DIFF
--- a/lib/Padre/Wx/Main.pm
+++ b/lib/Padre/Wx/Main.pm
@@ -5561,7 +5561,7 @@ sub on_prev_pane {
 
     $main->on_join_lines;
 
-Join current line with next one (à la B<vi> with C<Ctrl+J>). No return value.
+Join current line with next one (a la B<vi> with C<Ctrl+J>). No return value.
 
 =cut
 


### PR DESCRIPTION
It just replaces a malformed UTF8 character.
#33 
