### PR TITLE
Make CPAN task properly functioning with MetaCPAN::Client

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -130,6 +130,7 @@ requires 'Parse::Functions'         => '0.01';
 requires 'List::MoreUtils'          => '0.22';
 requires 'LWP'                      => '5.815';
 requires 'LWP::UserAgent'           => '5.815';
+requires 'MetaCPAN::Client'            => 0;
 requires 'Module::Build'            => '0.3603';
 requires 'Module::CoreList'         => '2.22';
 requires 'Module::Manifest'         => '0.07';

--- a/lib/Padre/Wx/CPAN.pm
+++ b/lib/Padre/Wx/CPAN.pm
@@ -331,7 +331,7 @@ sub render_search {
 	for my $rec (@$model) {
 
 		# Add a CPAN distribution and author as a row to the list
-		$list->InsertImageStringItem( $index, $rec->{documentation}, $self->{images}{file} );
+		$list->InsertImageStringItem( $index, $rec->{name}, $self->{images}{file} );
 		$list->SetItemData( $index, $index );
 		$list->SetItem( $index, 1, $rec->{author} );
 		$list->SetItemBackgroundColour( $index, $alternate_color ) unless $index % 2;
@@ -396,7 +396,7 @@ sub _sort_model {
 		@model = sort {
 			if ( $command eq 'search' )
 			{
-				$a->{documentation} cmp $b->{documentation};
+                $a->{name} cmp $b->{name};
 			} elsif ( $command eq 'recent' ) {
 				$a->{name} cmp $b->{name};
 			} elsif ( $command eq 'favorite' ) {


### PR DESCRIPTION
#40 doesn't work as expected. I couldn't really search for modules. This pull request uses MetaCPAN::Client instead for autocompleting the search field.